### PR TITLE
fix: DB id 자동생성 추가, timestamps 개선

### DIFF
--- a/models/answer.js
+++ b/models/answer.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class Answer extends Sequelize.Model {
   static init(sequelize) {
@@ -7,51 +7,63 @@ module.exports = class Answer extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         user_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "user",
-            key: "id",
+            model: 'user',
+            key: 'id',
           },
           //   onDelete: "CASCADE",
         },
         question_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "question",
-            key: "id",
+            model: 'question',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         contents: {
-          type: "varchar(255)",
+          type: 'varchar(255)',
           allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'Answer',
+        tableName: 'answer',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "Answer",
-        tableName: "answer",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.Answer.belongsTo(db.User, {
-      foreignKey: "user_id",
+      foreignKey: 'user_id',
       //   onDelete: "CASCADE",
     });
     db.Answer.belongsTo(db.Question, {
-      foreignKey: "question_id",
-      onDelete: "CASCADE",
+      foreignKey: 'question_id',
+      onDelete: 'CASCADE',
     });
   }
 };

--- a/models/category.js
+++ b/models/category.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class Category extends Sequelize.Model {
   static init(sequelize) {
@@ -7,30 +7,42 @@ module.exports = class Category extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         name: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'Category',
+        tableName: 'category',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "Category",
-        tableName: "category",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.Category.hasMany(db.Study, {
-      foreignKey: "category_id",
+      foreignKey: 'category_id',
     });
   }
 };

--- a/models/comment.js
+++ b/models/comment.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class Comment extends Sequelize.Model {
   static init(sequelize) {
@@ -7,51 +7,63 @@ module.exports = class Comment extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         study_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "study",
-            key: "id",
+            model: 'study',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         user_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "user",
-            key: "id",
+            model: 'user',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         contents: {
-          type: "varchar(255)",
+          type: 'varchar(255)',
           allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'Comment',
+        tableName: 'comment',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "Comment",
-        tableName: "comment",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.Comment.belongsTo(db.User, {
-      foreignKey: "user_id",
-      onDelete: "CASCADE",
+      foreignKey: 'user_id',
+      onDelete: 'CASCADE',
     });
     db.Comment.belongsTo(db.Study, {
-      foreignKey: "study_id",
-      onDelete: "CASCADE",
+      foreignKey: 'study_id',
+      onDelete: 'CASCADE',
     });
   }
 };

--- a/models/notice.js
+++ b/models/notice.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class Notice extends Sequelize.Model {
   static init(sequelize) {
@@ -7,42 +7,54 @@ module.exports = class Notice extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         user_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "user",
-            key: "id",
+            model: 'user',
+            key: 'id',
           },
           //   onDelete: "CASCADE",
         },
         title: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           allowNull: false,
         },
         contents: {
-          type: "varchar(255)",
+          type: 'varchar(255)',
           allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'Notice',
+        tableName: 'notice',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "Notice",
-        tableName: "notice",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.Notice.belongsTo(db.User, {
-      foreignKey: "user_id",
+      foreignKey: 'user_id',
       //   onDelete: "CASCADE",
     });
   }

--- a/models/pointHistory.js
+++ b/models/pointHistory.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class PointHistory extends Sequelize.Model {
   static init(sequelize) {
@@ -7,14 +7,15 @@ module.exports = class PointHistory extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         user_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "user",
-            key: "id",
+            model: 'user',
+            key: 'id',
           },
           //   onDelete: "CASCADE",
         },
@@ -30,23 +31,34 @@ module.exports = class PointHistory extends Sequelize.Model {
           type: Sequelize.TINYINT,
           allowNull: false,
         },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'PointHistory',
+        tableName: 'point_history',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "PointHistory",
-        tableName: "point_history",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.PointHistory.belongsTo(db.User, {
-      foreignKey: "user_id",
+      foreignKey: 'user_id',
       //   onDelete: "CASCADE",
     });
   }

--- a/models/question.js
+++ b/models/question.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class Question extends Sequelize.Model {
   static init(sequelize) {
@@ -7,46 +7,57 @@ module.exports = class Question extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         user_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "user",
-            key: "id",
+            model: 'user',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         title: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           allowNull: false,
         },
         contents: {
-          type: "varchar(255)",
+          type: 'varchar(255)',
           allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
       },
       {
         sequelize,
         timestamps: true,
         underscored: true,
-        modelName: "Question",
-        tableName: "question",
+        modelName: 'Question',
+        tableName: 'question',
         paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+      },
     );
   }
 
   static associate(db) {
     db.Question.belongsTo(db.User, {
-      foreignKey: "user_id",
-      onDelete: "CASCADE",
+      foreignKey: 'user_id',
+      onDelete: 'CASCADE',
     });
     db.Question.hasOne(db.Answer, {
-      foreignKey: "question_id",
+      foreignKey: 'question_id',
     });
   }
 };

--- a/models/reservation.js
+++ b/models/reservation.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class Reservation extends Sequelize.Model {
   static init(sequelize) {
@@ -7,19 +7,20 @@ module.exports = class Reservation extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         study_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "study",
-            key: "id",
+            model: 'study',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         reservation_person_name: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           allowNull: false,
         },
         status: {
@@ -27,34 +28,45 @@ module.exports = class Reservation extends Sequelize.Model {
           defaultValue: 0,
         },
         longitude: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           // allowNull: false,
         },
         latitude: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           // allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'Reservation',
+        tableName: 'reservation',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "Reservation",
-        tableName: "reservation",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.Reservation.belongsTo(db.Study, {
-      foreignKey: "study_id",
-      onDelete: "CASCADE",
+      foreignKey: 'study_id',
+      onDelete: 'CASCADE',
     });
     db.Reservation.hasMany(db.StudyRoomSchedule, {
-      foreignKey: "reservation_id",
+      foreignKey: 'reservation_id',
     });
   }
 };

--- a/models/review.js
+++ b/models/review.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class Review extends Sequelize.Model {
   static init(sequelize) {
@@ -7,55 +7,67 @@ module.exports = class Review extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         study_cafe_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "study_cafe",
-            key: "id",
+            model: 'study_cafe',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         user_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "user",
-            key: "id",
+            model: 'user',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         contents: {
-          type: "varchar(255)",
+          type: 'varchar(255)',
           allowNull: false,
         },
         rating: {
           type: Sequelize.INTEGER.UNSIGNED,
           allowNull: false,
         },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'Review',
+        tableName: 'review',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "Review",
-        tableName: "review",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.Review.belongsTo(db.User, {
-      foreignKey: "user_id",
-      onDelete: "CASCADE",
+      foreignKey: 'user_id',
+      onDelete: 'CASCADE',
     });
     db.Review.belongsTo(db.StudyCafe, {
-      foreignKey: "study_cafe_id",
-      onDelete: "CASCADE",
+      foreignKey: 'study_cafe_id',
+      onDelete: 'CASCADE',
     });
   }
 };

--- a/models/study.js
+++ b/models/study.js
@@ -7,6 +7,7 @@ module.exports = class Study extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
@@ -70,16 +71,27 @@ module.exports = class Study extends Sequelize.Model {
           type: 'varchar(255)',
           allowNull: true,
         },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
       },
       {
         sequelize,
-        timestamps: true,
-        underscored: true,
         modelName: 'Study',
         tableName: 'study',
-        paranoid: true,
         charset: 'utf8',
         collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
+        underscored: true,
       },
     );
   }

--- a/models/studyCafe.js
+++ b/models/studyCafe.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class StudyCafe extends Sequelize.Model {
   static init(sequelize) {
@@ -7,72 +7,84 @@ module.exports = class StudyCafe extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         user_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "user",
-            key: "id",
+            model: 'user',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         longitude: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           allowNull: false,
         },
         latitude: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           allowNull: false,
         },
         shop_number: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           allowNull: false,
         },
         name: {
-          type: "varchar(45)",
+          type: 'varchar(45)',
           allowNull: false,
         },
         info: {
-          type: "longtext",
+          type: 'longtext',
           allowNull: false,
         },
         operation_time: {
-          type: "varchar(255)",
+          type: 'varchar(255)',
           allowNull: false,
         },
         rating: {
           type: Sequelize.FLOAT,
           defaultValue: 0,
         },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'StudyCafe',
+        tableName: 'study_cafe',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "StudyCafe",
-        tableName: "study_cafe",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.StudyCafe.belongsTo(db.User, {
-      foreignKey: "user_id",
-      onDelete: "CASCADE",
+      foreignKey: 'user_id',
+      onDelete: 'CASCADE',
     });
     db.StudyCafe.hasMany(db.Review, {
-      foreignKey: "study_cafe_id",
+      foreignKey: 'study_cafe_id',
     });
     db.StudyCafe.hasMany(db.StudyCafeImage, {
-      foreignKey: "study_cafe_id",
+      foreignKey: 'study_cafe_id',
     });
     db.StudyCafe.hasMany(db.StudyRoom, {
-      foreignKey: "study_cafe_id",
+      foreignKey: 'study_cafe_id',
     });
   }
 };

--- a/models/studyCafeImage.js
+++ b/models/studyCafeImage.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class StudyCafeImage extends Sequelize.Model {
   static init(sequelize) {
@@ -7,39 +7,51 @@ module.exports = class StudyCafeImage extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         study_cafe_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "study_cafe",
-            key: "id",
+            model: 'study_cafe',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         src: {
-          type: "varchar(255)",
+          type: 'varchar(255)',
           allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'StudyCafeImage',
+        tableName: 'study_cafe_image',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "StudyCafeImage",
-        tableName: "study_cafe_image",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.StudyCafeImage.belongsTo(db.StudyCafe, {
-      foreignKey: "study_cafe_id",
-      onDelete: "CASCADE",
+      foreignKey: 'study_cafe_id',
+      onDelete: 'CASCADE',
     });
   }
 };

--- a/models/studyMember.js
+++ b/models/studyMember.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class StudyMember extends Sequelize.Model {
   static init(sequelize) {
@@ -7,24 +7,25 @@ module.exports = class StudyMember extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         study_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "study",
-            key: "id",
+            model: 'study',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         user_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "user",
-            key: "id",
+            model: 'user',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         late_cnt: {
           type: Sequelize.INTEGER.UNSIGNED,
@@ -38,28 +39,39 @@ module.exports = class StudyMember extends Sequelize.Model {
           type: Sequelize.INTEGER.UNSIGNED,
           defaultValue: 1,
         },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'StudyMember',
+        tableName: 'study_member',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "StudyMember",
-        tableName: "study_member",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.StudyMember.belongsTo(db.User, {
-      foreignKey: "user_id",
-      onDelete: "CASCADE",
+      foreignKey: 'user_id',
+      onDelete: 'CASCADE',
     });
     db.StudyMember.belongsTo(db.Study, {
-      foreignKey: "study_id",
-      onDelete: "CASCADE",
+      foreignKey: 'study_id',
+      onDelete: 'CASCADE',
     });
   }
 };

--- a/models/studyRoom.js
+++ b/models/studyRoom.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class StudyRoom extends Sequelize.Model {
   static init(sequelize) {
@@ -7,16 +7,17 @@ module.exports = class StudyRoom extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         study_cafe_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "study_cafe",
-            key: "id",
+            model: 'study_cafe',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         max_person: {
           type: Sequelize.INTEGER.UNSIGNED,
@@ -27,30 +28,41 @@ module.exports = class StudyRoom extends Sequelize.Model {
           allowNull: false,
         },
         src: {
-          type: "varchar(255)",
+          type: 'varchar(255)',
           allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'StudyRoom',
+        tableName: 'study_room',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "StudyRoom",
-        tableName: "study_room",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.StudyRoom.belongsTo(db.StudyCafe, {
-      foreignKey: "study_cafe_id",
-      onDelete: "CASCADE",
+      foreignKey: 'study_cafe_id',
+      onDelete: 'CASCADE',
     });
     db.StudyRoom.hasMany(db.StudyRoomSchedule, {
-      foreignKey: "studyroom_id",
+      foreignKey: 'studyroom_id',
     });
   }
 };

--- a/models/studyRoomSchedule.js
+++ b/models/studyRoomSchedule.js
@@ -1,4 +1,4 @@
-const Sequelize = require("sequelize");
+const Sequelize = require('sequelize');
 
 module.exports = class StudyRoomSchedule extends Sequelize.Model {
   static init(sequelize) {
@@ -7,55 +7,67 @@ module.exports = class StudyRoomSchedule extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
         reservation_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "reservation",
-            key: "id",
+            model: 'reservation',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         studyroom_id: {
           type: Sequelize.INTEGER.UNSIGNED,
           references: {
-            model: "study_room",
-            key: "id",
+            model: 'study_room',
+            key: 'id',
           },
-          onDelete: "CASCADE",
+          onDelete: 'CASCADE',
         },
         time: {
-          type: "datetime",
+          type: 'datetime',
           allowNull: false,
         },
         status: {
           type: Sequelize.INTEGER.UNSIGNED,
           allowNull: false,
         },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
       },
       {
         sequelize,
-        timestamps: true,
+        modelName: 'StudyRoomSchedule',
+        tableName: 'study_room_schedule',
+        charset: 'utf8',
+        collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
         underscored: true,
-        modelName: "StudyRoomSchedule",
-        tableName: "study_room_schedule",
-        paranoid: true,
-        charset: "utf8",
-        collate: "utf8_general_ci",
-      }
+      },
     );
   }
 
   static associate(db) {
     db.StudyRoomSchedule.belongsTo(db.StudyRoom, {
-      foreignKey: "studyroom_id",
-      onDelete: "CASCADE",
+      foreignKey: 'studyroom_id',
+      onDelete: 'CASCADE',
     });
     db.StudyRoomSchedule.belongsTo(db.Reservation, {
-      foreignKey: "reservation_id",
-      onDelete: "CASCADE",
+      foreignKey: 'reservation_id',
+      onDelete: 'CASCADE',
     });
   }
 };

--- a/models/user.js
+++ b/models/user.js
@@ -7,6 +7,7 @@ module.exports = class User extends Sequelize.Model {
         id: {
           primaryKey: true,
           type: Sequelize.INTEGER.UNSIGNED,
+          autoIncrement: true,
           allowNull: false,
           unique: true,
         },
@@ -50,16 +51,27 @@ module.exports = class User extends Sequelize.Model {
           type: 'varchar(255)',
           allowNull: true,
         },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: true,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
       },
       {
         sequelize,
-        timestamps: true,
-        underscored: true,
         modelName: 'User',
         tableName: 'user',
-        paranoid: true,
         charset: 'utf8',
         collate: 'utf8_general_ci',
+        initialAutoIncrement: 1,
+        timestamps: false,
+        paranoid: false,
+        underscored: true,
       },
     );
   }


### PR DESCRIPTION
## 작업 개요 
fix: DB id 자동생성 추가, timestamps 개선

## 상세 내용 
기존에 만들어진 sequelize 테이블 구조를 개선 
1. 모든 table의 id 자동 생성으로 변경
2. created_at과 updated_at 컬럼 자동생성(timstamps 이용) -> 수동작성 변경
    (이유 : 자동생성시 not null 해제 안됨 & default 값 지정 문제) 