### PR TITLE
Features/fix get study room schedules

### DIFF
--- a/routes/studyCafe.js
+++ b/routes/studyCafe.js
@@ -388,13 +388,15 @@ router.route('/:id/rooms/:rid/study-room-schedules').get(async (req, res) => {
     selectedDateFrom.setUTCHours(0);
     selectedDateTo.setDate(selectedDateTo.getDate() + 2);
     selectedDateTo.setUTCHours(0);
-    console.log(selectedDateFrom, selectedDateTo);
+
+    const todayDate = new Date();
+    todayDate.setHours(todayDate.getHours() + 9);
 
     const studyRoomSchedules = await StudyRoomSchedule.findAll({
       where: {
         studyRoomId: req.params.rid,
         datetime: {
-          [Op.gte]: selectedDateFrom,
+          [Op.gte]: todayDate > selectedDateFrom ? todayDate : selectedDateFrom,
           [Op.lt]: selectedDateTo,
         },
       },

--- a/routes/studyCafe.js
+++ b/routes/studyCafe.js
@@ -381,14 +381,24 @@ router
 
 router.route('/:id/rooms/:rid/study-room-schedules').get(async (req, res) => {
   try {
-    const selectedDate = new Date(req.query.date);
-    selectedDate.setDate(selectedDate.getDate() + 1);
+    // first aid to the timezone 9 hour problem
+    const selectedDateFrom = new Date(req.query.date);
+    const selectedDateTo = new Date(req.query.date);
+    selectedDateFrom.setDate(selectedDateFrom.getDate() + 1);
+    selectedDateFrom.setUTCHours(0);
+    selectedDateTo.setDate(selectedDateTo.getDate() + 2);
+    selectedDateTo.setUTCHours(0);
+    console.log(selectedDateFrom, selectedDateTo);
 
     const studyRoomSchedules = await StudyRoomSchedule.findAll({
       where: {
         studyRoomId: req.params.rid,
-        datetime: { [Op.gte]: new Date(req.query.date), [Op.lt]: selectedDate },
+        datetime: {
+          [Op.gte]: selectedDateFrom,
+          [Op.lt]: selectedDateTo,
+        },
       },
+      order: [['datetime', 'ASC']],
     });
     res.status(200).json(studyRoomSchedules);
   } catch (err) {


### PR DESCRIPTION
## 스터디룸 예약 시 사용자가 선택한 날짜의 스터디룸스케줄을 보내주는 API(GET study-cafes/:id/rooms/:rid/study-room-schedules) 수정
* 타임존 9시간 문제에 대한 응급처치
* 사용자가 선택한 날짜가 현재보다 같거나 오래된 날짜일 때에 대한 케이스 처리
